### PR TITLE
chore: link frontend and backend services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   backend:
     build: ./backend
     container_name: certificate-backend
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
       - ./backend:/app
     ports:
@@ -14,6 +14,6 @@ services:
     build: ./frontend
     container_name: certificate-frontend
     ports:
-      - "3000:80"
+      - "5173:80"
     depends_on:
       - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build React app
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 WORKDIR /app
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Description

**Summary of Changes**
- Updated `docker-compose.yml` to correctly link frontend and backend.
- Fixed port mappings:
  - Frontend now runs at `http://localhost:5173`.
  - Backend runs at `http://localhost:8000`.
- Ensured frontend can reach backend using `http://backend:8000` inside Docker network.
- Fixed backend service command to match `main:app`.
- Updated Node version from 18 to 20.

**Related Issue**
Closes #8 

## Type of Change
- [x] Chore (infrastructure/config update)

## Notes
After this update, running `docker-compose up` will start both services correctly linked.
