### PR TITLE
Configure Vite Dev Server for External Access

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 30000,
+  },
 })


### PR DESCRIPTION
## Configure Vite Dev Server for External Access

### Summary
Added server configuration to `vite.config.js` to enable external device access and use a fixed port.

### Changes
- Added `server` config with `host: '0.0.0.0'` and `port: 30000` to `frontend/vite.config.js`
- Enables dev server access from mobile devices and other computers on the network

### Benefits
- ✅ Dev server accessible from external devices (e.g., mobile phones)
- ✅ Fixed port (30000) for consistent URLs
- ✅ Better testing workflow for responsive designs

### Testing
- ✅ No linting errors
- ✅ Dev server runs successfully on port 30000
- ✅ Accessible via `http://<machine-ip>:30000`

### Usage
```bash
cd frontend
npm run dev
# Access from network: http://<your-ip>:30000
```
### 🔗 Related Issue
Closes #60 

---
**Type:** Enhancement  
**Breaking Changes:** None