### PR TITLE
feat: Implement SQLAlchemy persistence for certificates (fixes #102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Follow these steps to set up the project locally.
 
 ---
 
+## Database
+
+This project uses **SQLite** for persistent data storage.
+
+- **Database File:** A database file named `app.db` will be automatically created in the root of the project directory when you first run the backend server.
+- **Database Schema:** The database models are defined in `backend/app/models/certificates.py`.
+- **Data Persistence:** Certificate records are now saved to this database and will persist even after the server restarts.
+
+---
 
 ## 🎯 Planned Features
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+app.db
 
 # Ignore Jupyter Notebook checkpoints
 .ipynb_checkpoints/

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,14 @@ from fastapi.middleware.cors import CORSMiddleware
 
 # Relative imports within the same package
 from .api.certificates import router as certificates_router
+from .database import Base, engine
+from .models import certificates as certificate_models
 
 app = FastAPI(title="Hacktoberfest Certificate Generator")
+
+@app.on_event("startup")
+def create_db_tables():
+    Base.metadata.create_all(bind=engine)
 
 # Include routers
 app.include_router(certificates_router, prefix="/certificates", tags=["certificates"])

--- a/backend/app/models/certificates.py
+++ b/backend/app/models/certificates.py
@@ -214,40 +214,40 @@ class Certificate:
 # ORM Model stub using SQLAlchemy (for future database implementation)
 # Uncomment and configure when database support is added
 
-# from sqlalchemy import Column, String, DateTime
-# from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, String, DateTime
+from ..database import Base
 
-# Base = declarative_base()
+# Base = declarative_base() # This is now imported from ..database
 
-# class CertificateORM(Base):
-#     '''SQLAlchemy ORM model for Certificate'''
+class CertificateORM(Base):
+    '''SQLAlchemy ORM model for Certificate'''
     
-#     __tablename__ = 'certificates'
+    __tablename__ = 'certificates'
     
-#     unique_id = Column(String(50), primary_key=True, index=True)
-#     participant_name = Column(String(100), nullable=False, index=True)
-#     event_name = Column(String(200), nullable=False, index=True)
-#     date_issued = Column(String(10), nullable=False)
-#     filename = Column(String(255), nullable=False, unique=True)
-#     file_path = Column(String(500), nullable=True)
-#     created_at = Column(DateTime, default=datetime.now)
-#     updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
+    unique_id = Column(String(50), primary_key=True, index=True)
+    participant_name = Column(String(100), nullable=False, index=True)
+    event_name = Column(String(200), nullable=False, index=True)
+    date_issued = Column(String(10), nullable=False)
+    filename = Column(String(255), nullable=False, unique=True)
+    file_path = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=datetime.now)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
     
-#     def __repr__(self):
-#         return f"<Certificate(id={self.unique_id}, participant={self.participant_name})>"
+    def __repr__(self):
+        return f"<Certificate(id={self.unique_id}, participant={self.participant_name})>"
     
-#     def to_dict(self):
-#         '''Convert ORM model to dictionary'''
-#         return {
-#             'unique_id': self.unique_id,
-#             'participant_name': self.participant_name,
-#             'event_name': self.event_name,
-#             'date_issued': self.date_issued,
-#             'filename': self.filename,
-#             'file_path': self.file_path,
-#             'created_at': self.created_at.isoformat() if self.created_at else None,
-#             'updated_at': self.updated_at.isoformat() if self.updated_at else None
-#         }
+    def to_dict(self):
+        '''Convert ORM model to dictionary'''
+        return {
+            'unique_id': self.unique_id,
+            'participant_name': self.participant_name,
+            'event_name': self.event_name,
+            'date_issued': self.date_issued,
+            'filename': self.filename,
+            'file_path': self.file_path,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
 
 # # Database configuration (to be implemented)
 # # from sqlalchemy import create_engine


### PR DESCRIPTION
Resolves #102.

This pull request implements persistent database storage for the certificate generator, replacing the previous in-memory dictionary. Certificates are now saved to a SQLite database (`app.db`) and will persist across server restarts, fulfilling the issue's acceptance criteria.

### Changes Made

* **Model:** Uncommented the `CertificateORM` model in `backend/app/models/certificates.py` and linked it to the new `Base`.
* **Database Config:** Created `backend/app/database.py` to manage the SQLAlchemy `engine`, `SessionLocal`, and the declarative `Base`.
* **App Startup:** Updated `backend/app/main.py` with an `@app.on_event("startup")` handler to create all database tables automatically.
* **Endpoints:**
    * Refactored `POST /certificates/` to save new certificate records to the database.
    * Refactored `GET /certificates/{unique_id}` to query the database.
* **Dependency Injection:** Added and used the `get_db` dependency to provide a database session to the endpoints.
* **README:** Added a new "Database" section to the main `README.md` file.
* **.gitignore:** Updated `backend/.gitignore` to ignore the generated `app.db` file.

### How to Test

1.  Run the backend (`cd backend` and `uvicorn app.main:app --reload`).
2.  Verify that a new `app.db` file is created in the `backend/` directory.
3.  Go to `http://localhost:8000/docs` and use the `POST /certificates/` endpoint to create a new certificate.
4.  Copy the `unique_id` from the response.
5.  Stop the server (`Ctrl+C`).
6.  Restart the server (`uvicorn app.main:app --reload`).
7.  Use the `GET /certificates/{unique_id}` endpoint to request the certificate with the ID from step 4.

**Expected Result:** The endpoint will return a `200 OK` response with the certificate details, proving the data was successfully persisted.